### PR TITLE
Add support for MSVC runtime libraries from VS 2015

### DIFF
--- a/tinycc/distutils.py
+++ b/tinycc/distutils.py
@@ -57,6 +57,11 @@ def get_msvcr():
         elif msc_ver == '1600':
             # VS2010 / MSVC 10.0
             return ['msvcr100']
+        elif msc_ver == '1900':
+            # VS2015 / MSVC 14.0
+            # Universal CRT - see:
+            # https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/
+            return ['ucrtbase']
         else:
             raise ValueError("Unknown MS Compiler version %s " % msc_ver)
 

--- a/tinycc/distutils.py
+++ b/tinycc/distutils.py
@@ -61,9 +61,9 @@ def get_msvcr():
     elif msc_ver == 1600:
         # VS2010 / MSVC 10.0
         return ['msvcr100']
-    elif (msc_ver == 1900) or (1910 <= msc_ver <= 1914):
+    elif msc_ver >= 1900:
         # VS2015 / MSVC 14.0
-        # VS2017 / MSVC 14.1 - 14.14
+        # ... and later versions
         # Universal CRT - see:
         # https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/
         return ['ucrtbase']

--- a/tinycc/distutils.py
+++ b/tinycc/distutils.py
@@ -41,24 +41,29 @@ def get_msvcr():
     """
     msc_pos = sys.version.find('MSC v.')
     if msc_pos != -1:
-        msc_ver = sys.version[msc_pos+6:msc_pos+10]
-        if msc_ver == '1300':
+        msc_ver_str = sys.version[msc_pos+6:msc_pos+10]
+        try:
+            msc_ver = int(msc_ver_str)
+        except ValueError:
+            raise ValueError("Failed to parse MS compiler version: %s" % msc_ver_str)
+        if msc_ver == 1300:
             # MSVC 7.0
             return ['msvcr70']
-        elif msc_ver == '1310':
+        elif msc_ver == 1310:
             # MSVC 7.1
             return ['msvcr71']
-        elif msc_ver == '1400':
+        elif msc_ver == 1400:
             # VS2005 / MSVC 8.0
             return ['msvcr80']
-        elif msc_ver == '1500':
+        elif msc_ver == 1500:
             # VS2008 / MSVC 9.0
             return ['msvcr90']
-        elif msc_ver == '1600':
+        elif msc_ver == 1600:
             # VS2010 / MSVC 10.0
             return ['msvcr100']
-        elif msc_ver == '1900':
+        elif (msc_ver == 1900) or (1910 <= msc_ver <= 1914):
             # VS2015 / MSVC 14.0
+            # VS2017 / MSVC 14.1 - 14.14
             # Universal CRT - see:
             # https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/
             return ['ucrtbase']

--- a/tinycc/distutils.py
+++ b/tinycc/distutils.py
@@ -22,6 +22,7 @@ using .pth magic.
 from __future__ import absolute_import
 
 import os
+import platform
 import sys
 import copy
 from subprocess import Popen, PIPE, check_output
@@ -39,36 +40,35 @@ def get_msvcr():
     """Include the appropriate MSVC runtime library if Python was built
     with MSVC 7.0 or later.
     """
-    msc_pos = sys.version.find('MSC v.')
-    if msc_pos != -1:
-        msc_ver_str = sys.version[msc_pos+6:msc_pos+10]
-        try:
-            msc_ver = int(msc_ver_str)
-        except ValueError:
-            raise ValueError("Failed to parse MS compiler version: %s" % msc_ver_str)
-        if msc_ver == 1300:
-            # MSVC 7.0
-            return ['msvcr70']
-        elif msc_ver == 1310:
-            # MSVC 7.1
-            return ['msvcr71']
-        elif msc_ver == 1400:
-            # VS2005 / MSVC 8.0
-            return ['msvcr80']
-        elif msc_ver == 1500:
-            # VS2008 / MSVC 9.0
-            return ['msvcr90']
-        elif msc_ver == 1600:
-            # VS2010 / MSVC 10.0
-            return ['msvcr100']
-        elif (msc_ver == 1900) or (1910 <= msc_ver <= 1914):
-            # VS2015 / MSVC 14.0
-            # VS2017 / MSVC 14.1 - 14.14
-            # Universal CRT - see:
-            # https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/
-            return ['ucrtbase']
-        else:
-            raise ValueError("Unknown MS Compiler version %s " % msc_ver)
+    # sample python_compiler() output: 'MSC v.1929 64 bit (AMD64)'
+    msc_ver_str = platform.python_compiler().split(" ")[1][2:]
+    try:
+        msc_ver = int(msc_ver_str)
+    except ValueError:
+        raise ValueError("Failed to parse MS compiler version: %s" % msc_ver_str)
+    if msc_ver == 1300:
+        # MSVC 7.0
+        return ['msvcr70']
+    elif msc_ver == 1310:
+        # MSVC 7.1
+        return ['msvcr71']
+    elif msc_ver == 1400:
+        # VS2005 / MSVC 8.0
+        return ['msvcr80']
+    elif msc_ver == 1500:
+        # VS2008 / MSVC 9.0
+        return ['msvcr90']
+    elif msc_ver == 1600:
+        # VS2010 / MSVC 10.0
+        return ['msvcr100']
+    elif (msc_ver == 1900) or (1910 <= msc_ver <= 1914):
+        # VS2015 / MSVC 14.0
+        # VS2017 / MSVC 14.1 - 14.14
+        # Universal CRT - see:
+        # https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/
+        return ['ucrtbase']
+    else:
+        raise ValueError("Unknown MS Compiler version %s " % msc_ver)
 
 class TinyCCompiler(UnixCCompiler):
     """ Handles the TinyCC compiler in Windows.


### PR DESCRIPTION
The (usual) Windows binaries for Python 3.5.0 and newer are built with Visual Studio 2015 (MSC v.1900, runtime v140), which is not currently handled by tinycc, which means Python 3.5+ is unsupported.

This should fix it. Note the change in DLL name: https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/